### PR TITLE
[Feat] Add checksum for donwload and upload file methods

### DIFF
--- a/gcp_io/gcp_interface.py
+++ b/gcp_io/gcp_interface.py
@@ -1,4 +1,3 @@
-from ast import Return
 import base64
 import binascii
 import datetime
@@ -152,7 +151,7 @@ class GCPInterface(object):
             md5_hash = md5sum(file)
         return md5_hash
 
-    def check_sum(self, gcs_file: str, local_file: str) -> bool:
+    def check_md5sum(self, gcs_file: str, local_file: str) -> bool:
         
         """! Check if there are differences between a local file and one in GCP
         @param gcs_file (str) Full path to the file in cloud storage.
@@ -214,35 +213,35 @@ class GCPInterface(object):
         self,
         src_file: str,
         dst_file: str,
-        checks_changes: bool = True,
+        md5sum_check: bool = True,
     ):
         """! Downloads the file from cloud storage to local file
         @param src_file (str) Full path to the file in cloud storage.
         @param dst_file (str) Full path to the file to be downloaded.
-        @param checks_changes (bool) Option to check if the file has changed.
+        @param md5sum_check (bool) Option to check if the file has changed.
         """
-        if checks_changes and self.check_sum(src_file, dst_file):
-            return False
+        if md5sum_check and self.check_md5sum(src_file, dst_file):
+            return None
         #print("Downloading file")
         content_bytes = self.get_bytes(src_file)
         with open(dst_file, "wb") as f:
             f.write(content_bytes)
-        return True
+        return None
 
     def upload_file(
         self, 
         local_file: str, 
         gcs_file: str, 
-        checks_changes: bool = True):
+        md5sum_check: bool = True):
         """Uploads a local file to google cloud storage
         @local_file (str): Full path to the local file
         @gcs_file (str): Full path to the bucket file
-        @param checks_changes (bool) Option to check if the file has changed.
+        @param md5sum_check (bool) Option to check if the file has changed.
         """
-        if checks_changes and self.check_sum(gcs_file, local_file):
-            return False
+        if md5sum_check and self.check_md5sum(gcs_file, local_file):
+            return None
         self.blob(gcs_file).upload_from_filename(local_file)
-        return True
+        return None
 
     def read_video(self, filepath: str) -> Tuple[List[np.ndarray], Dict[str, Any]]:
         """! Reads a video from a local file or remote file and returns a list of

--- a/gcp_io/gcp_interface.py
+++ b/gcp_io/gcp_interface.py
@@ -227,7 +227,7 @@ class GCPInterface(object):
         """! Downloads the file from cloud storage to local file
         @param src_file (str) Full path to the file in cloud storage.
         @param dst_file (str) Full path to the file to be downloaded.
-        @param checks_cahnges (bool) Option to check if the file has changed.
+        @param checks_changes (bool) Option to check if the file has changed.
         """
         if checks_cahnges:
             if self.check_sum(src_file, dst_file):
@@ -245,7 +245,7 @@ class GCPInterface(object):
         """Uploads a local file to google cloud storage
         @local_file (str): Full path to the local file
         @gcs_file (str): Full path to the bucket file
-        @param checks_cahnges (bool) Option to check if the file has changed.
+        @param checks_changes (bool) Option to check if the file has changed.
         """
         if checks_cahnges:
             if self.check_sum(gcs_file, local_file):

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -4,7 +4,7 @@ import os
 import json
 from typing import Any, Dict
 
-from gcp_io.gcp_interface import GCPInterface
+from gcp_io import GCPInterface
 
 interface = GCPInterface()
 
@@ -25,16 +25,17 @@ class TestFilesMethods(unittest.TestCase):
     
     def test_dowload_files(self):
         gcs_url = "gs://gcp-io-tests/files/test_donwload.json"
-        downloaded_file = interface.download_file(gcs_url, "test_donwload.json")
+        interface.download_file(gcs_url, "test_donwload.json")
+        downloaded_file = os.path.exists("test_donwload.json")
         os.remove("test_donwload.json") 
-        assert downloaded_file is True
+        assert downloaded_file
 
     def test_repeated_dowload_files(self):
         gcs_url = "gs://gcp-io-tests/files/test_donwload.json"
         interface.download_file(gcs_url, "test_donwload.json")
-        downloaded_file = interface.download_file(gcs_url, "test_donwload.json")
+        downloaded_file = interface.check_md5sum(gcs_url, "test_donwload.json")
         os.remove("test_donwload.json") 
-        assert downloaded_file is False
+        assert downloaded_file
 
     def test_upload_files(self):
         gcs_url = "gs://gcp-io-tests/files/test_donwload.json"
@@ -44,15 +45,15 @@ class TestFilesMethods(unittest.TestCase):
             data["C"] = 3
             with open("test_donwload_updated.json", "w") as json_updated:
                 json.dump(data,json_updated)
-        uploaded_file = interface.upload_file("test_donwload_updated.json", gcs_url)
+        uploaded_file = interface.check_md5sum(gcs_url, "test_donwload_updated.json")
         interface.upload_file("test_donwload.json", gcs_url)
         os.remove("test_donwload.json")
         os.remove("test_donwload_updated.json") 
-        assert uploaded_file is True
+        assert not uploaded_file
 
     def test_upload_repeated_files(self):
         gcs_url = "gs://gcp-io-tests/files/test_donwload.json"
         interface.download_file(gcs_url, "test_donwload.json")
-        uploaded_file = interface.upload_file("test_donwload.json", gcs_url)
+        uploaded_file = interface.check_md5sum(gcs_url, "test_donwload.json")
         os.remove("test_donwload.json") 
-        assert uploaded_file is False
+        assert uploaded_file

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -1,8 +1,10 @@
 import unittest
 import urllib.request
+import os
+import json
 from typing import Any, Dict
 
-from gcp_io import GCPInterface
+from gcp_io.gcp_interface import GCPInterface
 
 interface = GCPInterface()
 
@@ -20,3 +22,37 @@ class TestFilesMethods(unittest.TestCase):
         with self.assertRaises(Exception):
             signed_url = interface.gcs2signed(gcs_url, expiration_mins=1)
             assert signed_url is None
+    
+    def test_dowload_files(self):
+        gcs_url = "gs://gcp-io-tests/files/test_donwload.json"
+        downloaded_file = interface.download_file(gcs_url, "test_donwload.json")
+        os.remove("test_donwload.json") 
+        assert downloaded_file is True
+
+    def test_repeated_dowload_files(self):
+        gcs_url = "gs://gcp-io-tests/files/test_donwload.json"
+        interface.download_file(gcs_url, "test_donwload.json")
+        downloaded_file = interface.download_file(gcs_url, "test_donwload.json")
+        os.remove("test_donwload.json") 
+        assert downloaded_file is False
+
+    def test_upload_files(self):
+        gcs_url = "gs://gcp-io-tests/files/test_donwload.json"
+        interface.download_file(gcs_url, "test_donwload.json")
+        with open("test_donwload.json", "r") as json_downloaded :
+            data = json.load(json_downloaded)
+            data["C"] = 3
+            with open("test_donwload_updated.json", "w") as json_updated:
+                json.dump(data,json_updated)
+        uploaded_file = interface.upload_file("test_donwload_updated.json", gcs_url)
+        interface.upload_file("test_donwload.json", gcs_url)
+        os.remove("test_donwload.json")
+        os.remove("test_donwload_updated.json") 
+        assert uploaded_file is True
+
+    def test_upload_repeated_files(self):
+        gcs_url = "gs://gcp-io-tests/files/test_donwload.json"
+        interface.download_file(gcs_url, "test_donwload.json")
+        uploaded_file = interface.upload_file("test_donwload.json", gcs_url)
+        os.remove("test_donwload.json") 
+        assert uploaded_file is False


### PR DESCRIPTION
This PR adds a function that checks if the binaries of the files to be uploaded or downloaded are the same, if they are, it skips downloading/uploading them, when it finds differences or does not find the file it downloads/uploads them. To test it I use the library with a simple test file, download and upload the file and run it several times to verify that it was not uploading when it did not change and that when it did not exist or when there was a change it performed the appropriate action.