### PR TITLE
Update gcs2signed to be able to pass external credentials

### DIFF
--- a/gcp_io/__init__.py
+++ b/gcp_io/__init__.py
@@ -1,4 +1,4 @@
 from .gcp_interface import GCPInterface
 from .utils import write_video, md5sum, read_yaml, signed2gcs
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"


### PR DESCRIPTION
To create signed URLs you usually need a service account key file and the Application Default Credentials are not supported by default. 

There is a workaround for this, which is using impersonated credentials. See: https://blog.salrashid.dev/articles/2021/cloud_sdk_missing_manual/gcs_signedurl/ and https://cloud.google.com/iam/docs/impersonating-service-accounts.
       
For that we need a way to pass custom credentials to the generate_signed_url function. 