### PR TITLE
Add method to read video as a generator of frames

### DIFF
--- a/gcp_io/gcp_interface.py
+++ b/gcp_io/gcp_interface.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Generator, Iterator, List, Optional, Tuple, Union
 
 import imageio as iio
 import numpy as np
@@ -14,7 +14,14 @@ import yaml
 from google.cloud import storage
 from google.oauth2 import service_account
 
-from .utils import decode_video, get_bucket_and_path, md5sum, read_yaml, write_video
+from .utils import (
+    decode_video,
+    decode_video_gen,
+    get_bucket_and_path,
+    md5sum,
+    read_yaml,
+    write_video,
+)
 
 
 class GCPInterface(object):
@@ -169,7 +176,6 @@ class GCPInterface(object):
         return md5_hash
 
     def check_md5sum(self, gcs_file: str, local_file: str) -> bool:
-
         """! Check if there are differences between a local file and one in GCP
         @param gcs_file (str) Full path to the file in cloud storage.
         @param local_file (str) Full path to the local file.
@@ -268,6 +274,21 @@ class GCPInterface(object):
             video_bytes = open(filepath, "rb").read()
 
         return decode_video(video_bytes)
+
+    def read_video_gen(
+        self, filepath: str
+    ) -> Generator[Tuple[np.ndarray, Dict[str, Any]], None, None]:
+        """! Reads a video from a local file or remote file and returns a list of
+            frames and metadata. It uses imageio and ffmpeg to decode the video.
+        @param filepath (str) Full path to the video file.
+        @returns (Tuple[List[np.ndarray], Dict[str, Any]]) List of frames and metadata.
+        """
+        if "gs://" in filepath:
+            video_bytes = self.get_bytes(filepath)
+        else:
+            video_bytes = open(filepath, "rb").read()
+
+        return decode_video_gen(video_bytes)
 
     def write_video(
         self,

--- a/gcp_io/utils.py
+++ b/gcp_io/utils.py
@@ -1,7 +1,7 @@
 import hashlib
 import re
 from functools import partial
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Generator, List, Tuple
 
 import imageio
 import numpy as np
@@ -94,3 +94,17 @@ def decode_video(video_bytes: bytes) -> Tuple[List[np.ndarray], Dict[str, Any]]:
         for image in reader:
             frames.append(image)
     return frames, meta
+
+
+def decode_video_gen(
+    video_bytes: bytes,
+) -> Generator[Tuple[np.ndarray, Dict[str, Any]], None, None]:
+    """! Decodes video from bytes to numpy array and metadata dict.
+        It uses ffmpeg as backend.
+    @param video_bytes (bytes) Video bytes.
+    @return Tuple[List[np.ndarray], Dict[str, Any]] List of frames and metadata.
+    """
+    with imageio.get_reader(video_bytes, "ffmpeg") as reader:
+        meta = reader.get_meta_data()
+        for image in reader:
+            yield image, meta

--- a/test/test_video.py
+++ b/test/test_video.py
@@ -39,6 +39,17 @@ class TestVideoMethods(unittest.TestCase):
         frames = self.get_frames((32, 32, 3), 10)
         self.read_write_test(self.local_video, frames)
 
+    def test_gen_video(self):
+        video_generator = interface.read_video_gen(
+            "gs://gcp-io-tests/video/video_rgb.mp4"
+        )
+        # Assert video_generator is a generator
+        assert hasattr(video_generator, "__iter__")
+        for data in video_generator:
+            frame, metadata = data
+            assert isinstance(frame, np.ndarray)
+            assert isinstance(metadata, dict)
+
     # HINT: imageio seems to not support gray and rgba videos, always produces rgb videos
     # def test_read_video_gray(self):
     #     frames = self.get_frames((32, 32), 10)


### PR DESCRIPTION
Adds method `read_video_gen` that yields frames and metadata instead of a list with the frames